### PR TITLE
회원가입 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Custom ###
+application-secret.yml

--- a/build.gradle
+++ b/build.gradle
@@ -22,12 +22,19 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	annotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/likelion/ecommhub/EcommhubApplication.java
+++ b/src/main/java/com/likelion/ecommhub/EcommhubApplication.java
@@ -2,7 +2,9 @@ package com.likelion.ecommhub;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class EcommhubApplication {
 

--- a/src/main/java/com/likelion/ecommhub/config/EncoderConfig.java
+++ b/src/main/java/com/likelion/ecommhub/config/EncoderConfig.java
@@ -1,0 +1,14 @@
+package com.likelion.ecommhub.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class EncoderConfig {
+
+    @Bean
+    public BCryptPasswordEncoder encoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/likelion/ecommhub/config/auth/AuthenticationConfig.java
+++ b/src/main/java/com/likelion/ecommhub/config/auth/AuthenticationConfig.java
@@ -1,0 +1,41 @@
+package com.likelion.ecommhub.config.auth;
+
+import com.likelion.ecommhub.config.auth.JwtProvider;
+import com.likelion.ecommhub.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class AuthenticationConfig {
+
+    private final MemberService memberService;
+    private final JwtProvider jwtProvider;
+
+    @Value("${jwt.token.secretKey}")
+    private String secretKey;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .httpBasic().disable()
+                .csrf().disable()
+                .cors().and()
+                .authorizeRequests()
+                .antMatchers("/").permitAll()
+                .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .addFilterBefore(new JwtFilter(memberService, secretKey, jwtProvider), UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+}

--- a/src/main/java/com/likelion/ecommhub/config/auth/JwtFilter.java
+++ b/src/main/java/com/likelion/ecommhub/config/auth/JwtFilter.java
@@ -1,0 +1,90 @@
+package com.likelion.ecommhub.config.auth;
+
+import com.likelion.ecommhub.service.MemberService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final MemberService memberService;
+    private final String secretKey;
+    private final JwtProvider jwtProvider;
+
+    public JwtFilter(MemberService memberService, String secretKey, JwtProvider jwtProvider) {
+        this.memberService = memberService;
+        this.secretKey = secretKey;
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        final String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+        log.info("authorization : {}", authorization);
+
+        if (isAuthorizationNotExist(request, response, filterChain, authorization)) return;
+
+        // Token 꺼내기
+        String token = authorization.split(" ")[1];
+
+        // Token 만료
+        if (isTokenExpired(request, response, filterChain, token)) return;
+
+        String username = jwtProvider.getUsername(token);
+        log.info("username : {}", username);
+
+        // 권한 부여
+        authorize(request, response, filterChain, username);
+    }
+
+    private boolean isAuthorizationNotExist(HttpServletRequest request,
+                                            HttpServletResponse response,
+                                            FilterChain filterChain, String authorization) throws IOException, ServletException {
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            log.info("authorization 이 없거나 잘못 보냈습니다.");
+            filterChain.doFilter(request, response);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isTokenExpired(HttpServletRequest request,
+                                   HttpServletResponse response,
+                                   FilterChain filterChain,
+                                   String token) throws IOException, ServletException {
+        if (jwtProvider.isExpired(token)) {
+            log.error("Token이 만료 되었습니다.");
+            filterChain.doFilter(request, response);
+            return true;
+        }
+        return false;
+    }
+
+    private void authorize(HttpServletRequest request,
+                           HttpServletResponse response,
+                           FilterChain filterChain,
+                           String username) throws IOException, ServletException {
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(username, null, List.of(new SimpleGrantedAuthority("USER")));
+        // Detail 넣기
+        authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/likelion/ecommhub/config/auth/JwtProvider.java
+++ b/src/main/java/com/likelion/ecommhub/config/auth/JwtProvider.java
@@ -1,0 +1,59 @@
+package com.likelion.ecommhub.config.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    private final SecretKey secretKey;
+    private final long validityInMilliseconds;
+
+    public JwtProvider(@Value("${jwt.token.secretKey}") final String secretKey,
+                       @Value("${jwt.token.expire-length}") final long validityInMilliseconds) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.validityInMilliseconds = validityInMilliseconds;
+    }
+
+    public String createToken(String username) {
+        Claims claims = Jwts.claims();
+        claims.put("username", username);
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean isExpired(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration()
+                .before(new Date());
+    }
+
+    public String getUsername(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("username", String.class);
+
+    }
+}

--- a/src/main/java/com/likelion/ecommhub/domain/BaseEntity.java
+++ b/src/main/java/com/likelion/ecommhub/domain/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.likelion.ecommhub.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+}

--- a/src/main/java/com/likelion/ecommhub/domain/Gender.java
+++ b/src/main/java/com/likelion/ecommhub/domain/Gender.java
@@ -1,0 +1,5 @@
+package com.likelion.ecommhub.domain;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/src/main/java/com/likelion/ecommhub/domain/Member.java
+++ b/src/main/java/com/likelion/ecommhub/domain/Member.java
@@ -1,0 +1,75 @@
+package com.likelion.ecommhub.domain;
+
+import lombok.*;
+
+import javax.persistence.*;
+import javax.validation.constraints.Email;
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String loginId;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Email
+    private String email;
+
+    @Column(nullable = false)
+    private String phone; // 기존 seller_number에서 변경
+
+    @Column(nullable = false)
+    private String address;
+
+    private LocalDate birthDay;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    private MemberRole memberRole;
+
+    private String account; // 계좌번호는 String을 권장 (ex, 019-1234136-1234)
+
+    public Member(String loginId, String password, String name,
+                  String email, String phone, String address,
+                  LocalDate birthDay, Gender gender, MemberRole memberRole) {
+        this.loginId = loginId;
+        this.password = password;
+        this.name = name;
+        this.email = email;
+        this.phone = phone;
+        this.address = address;
+        this.birthDay = birthDay;
+        this.gender = gender;
+        this.memberRole = memberRole;
+    }
+
+    public Member(String loginId, String password, String name,
+                  String email, String phone, String address,
+                  LocalDate birthDay, Gender gender, MemberRole memberRole, String account) {
+        this.loginId = loginId;
+        this.password = password;
+        this.name = name;
+        this.email = email;
+        this.phone = phone;
+        this.address = address;
+        this.birthDay = birthDay;
+        this.gender = gender;
+        this.memberRole = memberRole;
+        this.account = account;
+    }
+}

--- a/src/main/java/com/likelion/ecommhub/domain/MemberRole.java
+++ b/src/main/java/com/likelion/ecommhub/domain/MemberRole.java
@@ -1,0 +1,5 @@
+package com.likelion.ecommhub.domain;
+
+public enum MemberRole {
+    ROLE_SELLER, ROLE_BUYER, ROLE_GUEST
+}

--- a/src/main/java/com/likelion/ecommhub/repository/MemberRepository.java
+++ b/src/main/java/com/likelion/ecommhub/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.likelion.ecommhub.repository;
+
+import com.likelion.ecommhub.domain.Member;
+import com.likelion.ecommhub.domain.MemberRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    List<Member> findByMemberRole(MemberRole memberRole);
+}

--- a/src/main/java/com/likelion/ecommhub/service/MemberService.java
+++ b/src/main/java/com/likelion/ecommhub/service/MemberService.java
@@ -1,0 +1,7 @@
+package com.likelion.ecommhub.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberService {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 spring:
   profiles:
     active: local
+    include: secret
   datasource:
     url: jdbc:mysql://127.0.0.1:3306/ecommhub__dev?useUnicode=true&characterEncoding=utf8&autoReconnect=true&serverTimezone=Asia/Seoul
     username: ecommhub

--- a/src/test/java/com/likelion/ecommhub/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/likelion/ecommhub/repository/MemberRepositoryTest.java
@@ -3,19 +3,16 @@ package com.likelion.ecommhub.repository;
 import com.likelion.ecommhub.domain.Gender;
 import com.likelion.ecommhub.domain.Member;
 import com.likelion.ecommhub.domain.MemberRole;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
@@ -50,7 +47,6 @@ class MemberRepositoryTest {
     }
 
     @Test
-    @Rollback(value = false)
     @DisplayName("Member 엔티티 save 확인 테스트")
     void memberInsertTest() {
         // give

--- a/src/test/java/com/likelion/ecommhub/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/likelion/ecommhub/repository/MemberRepositoryTest.java
@@ -1,0 +1,68 @@
+package com.likelion.ecommhub.repository;
+
+import com.likelion.ecommhub.domain.Gender;
+import com.likelion.ecommhub.domain.Member;
+import com.likelion.ecommhub.domain.MemberRole;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class MemberRepositoryTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @BeforeEach
+    void init() {
+        Member buyer_A = new Member("buyer_A", "buyer1234", "구매자1",
+                "buyer_A@gmail.com", "010-1111-1111", "서울시 노원구",
+                LocalDate.now(), Gender.MALE, MemberRole.ROLE_BUYER);
+        Member buyer_B = new Member("buyer_B", "buyer1234", "구매자2",
+                "buyer_B@hanmail.net", "010-2222-2222", "창원시 귀현동",
+                LocalDate.now(), Gender.MALE, MemberRole.ROLE_BUYER);
+        Member buyer_C = new Member("buyer_A", "buyer1234", "구매자3",
+                "buyer_C@naver.com", "010-3333-3333", "서울시 반포동",
+                LocalDate.now(), Gender.FEMALE, MemberRole.ROLE_BUYER);
+        memberRepository.save(buyer_A);
+        memberRepository.save(buyer_B);
+        memberRepository.save(buyer_C);
+
+        Member seller_A = new Member("seller_A", "seller1234", "판매자1",
+                "seller_A@naver.com", "010-4444-4444", "서울시 서초구",
+                LocalDate.now(), Gender.FEMALE, MemberRole.ROLE_SELLER);
+        Member seller_B = new Member("seller_B", "seller1234", "판매자2",
+                "seller_B@gmail.com", "010-4444-4444", "서울시 강남구",
+                LocalDate.now(), Gender.MALE, MemberRole.ROLE_SELLER);
+        memberRepository.save(seller_A);
+        memberRepository.save(seller_B);
+    }
+
+    @Test
+    @Rollback(value = false)
+    @DisplayName("Member 엔티티 save 확인 테스트")
+    void memberInsertTest() {
+        // give
+
+        // when
+        int count_buyer = memberRepository.findByMemberRole(MemberRole.ROLE_BUYER).size();
+        int count_seller = memberRepository.findByMemberRole(MemberRole.ROLE_SELLER).size();
+        int countAll = memberRepository.findAll().size();
+
+        // then
+        assertThat(count_buyer).isEqualTo(3);
+        assertThat(count_seller).isEqualTo(2);
+        assertThat(countAll).isEqualTo(5);
+    }
+}


### PR DESCRIPTION
close #1

- 회원가입 기능 추가
- Seller, Buyer 엔티티를 Member 엔티티로 우선 구현
- JWT 토큰 비교해 회원 비밀번호 비교
- 비밀번호 암호화
- 개발의 용이성을 위해 전화번호, 주소 암화화 하지않음, 추후 해당 암호화를 추가 해야함