### PR TITLE
상품 정렬 로직&UI 수정

### DIFF
--- a/src/main/java/com/likelion/ecommhub/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/likelion/ecommhub/repository/ProductRepositoryImpl.java
@@ -74,8 +74,12 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
     private OrderSpecifier<?> getOrderByExpression(int sortCode) {
         QProduct product = QProduct.product;
+        if (sortCode == 1) {
+            return product.createdDate.asc();
+        }
+
         if (sortCode == 2) {
-            return product.inventory.desc();
+            return product.price.asc();
         }
 
         if (sortCode == 3) {

--- a/src/main/resources/templates/product/home.html
+++ b/src/main/resources/templates/product/home.html
@@ -118,11 +118,11 @@
                 th:classappend="${page == pagingProducts.number} ? 'active'"
                 class="page-item">
                 <a th:text="${page + 1}" class="page-link"
-                   th:href="@{/product/search(page=${page}, productName=${param.productName}, sellerName=${param.sellerName}, productState=${param.productState})}"></a>
+                   th:href="@{/product/search(page=${page}, productName=${param.productName}, sellerName=${param.sellerName}, productState=${param.productState},sortCode= ${param.sortCode})}"></a>
             </li>
             <li class="page-item" th:classappend="${!pagingProducts.hasNext} ? 'disabled'">
                 <a class="page-link"
-                   th:href="@{/product/search(page=${pagingProducts.number+1}, productName=${param.productName}, sellerName=${param.sellerName}, productState=${param.productState})}">
+                   th:href="@{/product/search(page=${pagingProducts.number+1}, productName=${param.productName}, sellerName=${param.sellerName}, productState=${param.productState},sortCode= ${param.sortCode})}">
                     <span aria-hidden="true">&raquo;</span>
                 </a>
             </li>

--- a/src/main/resources/templates/product/home.html
+++ b/src/main/resources/templates/product/home.html
@@ -109,7 +109,7 @@
         <ul class="pagination justify-content-center">
             <li class="page-item" th:classappend="${!pagingProducts.hasPrevious} ? 'disabled'">
                 <a class="page-link"
-                   th:href="@{/product/search(page=${pagingProducts.number-1}, productName=${param.productName}, sellerName=${param.sellerName}, productState=${param.productState})}">
+                   th:href="@{/product/search(page=${pagingProducts.number-1}, productName=${param.productName}, sellerName=${param.sellerName}, productState=${param.productState},sortCode= ${param.sortCode})}">
                     <span aria-hidden="true">&laquo;</span>
                 </a>
             </li>

--- a/src/main/resources/templates/product/home.html
+++ b/src/main/resources/templates/product/home.html
@@ -47,16 +47,11 @@
                 <div class="dropdown dropdown-right dropdown-end">
                     <label tabindex="0" class="btn m-1">정렬</label>
                     <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52">
-                        <li><a onclick="sendSortRequest(0)">정렬</a></li>
-                        <li><a onclick="sendSortRequest(1)">날짜순</a></li>
-                        <li><a onclick="sendSortRequest(2)">재고량순</a></li>
-                        <li><a onclick="sendSortRequest(3)">가격</a></li>
+                        <li><a onclick="sendSortRequest(0)">최신순</a></li>
+                        <li><a onclick="sendSortRequest(1)">오래된순</a></li>
+                        <li><a onclick="sendSortRequest(2)">낮은 가격순</a></li>
+                        <li><a onclick="sendSortRequest(3)">높은 가격순</a></li>
                     </ul>
-                </div>
-                <div>
-                    <input type="radio" name="radio-1" class="radio" checked/>
-                    <input type="radio" name="radio-1" class="radio"/>
-                    <input type="radio" name="radio-1" class="radio"/>
                 </div>
                 <!--                <select name="sortCode" class="justify-end">
                                     <option value="0">정렬</option>


### PR DESCRIPTION
close #125 

정렬 기준을 변경하였습니다.
날짜순 -> 최신순 / 오래된 순
가격순 -> 낮은 가격순 / 높은 가격순
재고량순 -> x 

그에 따른 queryDsl 수정 하였습니다.

페이지 이동 시 sortCode가 누락되어 추가해 주었습니다.